### PR TITLE
[LIVE-DS-430] : Return error in case of failure is encountered when XGBoost model is read from binary file or json file instead of panic & remove unreachable code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dmitryikh/leaves
+module github.com/ishanbhattacharya1/leaves
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/dmitryikh/leaves
 
-go 1.16
+go 1.20
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ishanbhattacharya1/leaves
+module github.com/dmitryikh/leaves
 
 go 1.20
 

--- a/internal/xgjson/gbtree_model.go
+++ b/internal/xgjson/gbtree_model.go
@@ -1,6 +1,8 @@
 package xgjson
 
-import "github.com/dmitryikh/leaves/internal/xgbin"
+import (
+	"github.com/dmitryikh/leaves/internal/xgbin"
+)
 
 type GBTreeJson struct {
 	Learner GBTreeLearner `json:"learner"`

--- a/internal/xgjson/gbtree_model.go
+++ b/internal/xgjson/gbtree_model.go
@@ -39,7 +39,7 @@ type Tree struct {
 	SplitIndices       []uint32        `json:"split_indices"`
 	SplitConditions    []float32       `json:"split_conditions"`
 	SplitType          []int32         `json:"split_type"`
-	DefaultLeft        []bool          `json:"default_left"`
+	DefaultLeft        []int32         `json:"default_left"`
 	Categories         []int32         `json:"categories"`
 	CategoriesNodes    []int32         `json:"categories_nodes"`
 	CategoriesSegments []int32         `json:"categories_segments"`
@@ -68,8 +68,8 @@ func (t *Tree) toBinTreeModel() *xgbin.TreeModel {
 		nodes[idx].CRight = t.RightChildren[idx]
 		nodes[idx].CLeft = t.LeftChildren[idx]
 		nodes[idx].Parent = t.Parents[idx]
-		nodes[idx].Parent = int32(uint32(t.Parents[idx]) | 1 << 31)
-		if t.DefaultLeft[idx] {
+		nodes[idx].Parent = int32(uint32(t.Parents[idx]) | 1<<31)
+		if t.DefaultLeft[idx] > 0 {
 			t.SplitIndices[idx] |= 1 << 31
 		}
 		nodes[idx].SIndex = t.SplitIndices[idx]

--- a/lgensemble_io.go
+++ b/lgensemble_io.go
@@ -41,7 +41,7 @@ type lgNodeJSON struct {
 	// Threshold could be float64 (for numerical decision) or string (for categorical, example "10||100||400")
 	Threshold     interface{}     `json:"threshold"`
 	DecisionType  string          `json:"decision_type"`
-	DefaultLeft   bool            `json:"default_left"`
+	DefaultLeft   int32           `json:"default_left"`
 	MissingType   string          `json:"missing_type"`
 	LeftChildRaw  json.RawMessage `json:"left_child"`
 	RightChildRaw json.RawMessage `json:"right_child"`
@@ -472,7 +472,7 @@ func unmarshalTree(raw []byte) (lgTree, error) {
 			return node, fmt.Errorf("unknown missing_type '%s'", nodeJSON.MissingType)
 		}
 		defaultType := uint8(0)
-		if nodeJSON.DefaultLeft {
+		if nodeJSON.DefaultLeft > 0 {
 			defaultType = defaultLeft
 		}
 		threshold, ok := nodeJSON.Threshold.(float64)

--- a/lgtree.go
+++ b/lgtree.go
@@ -43,7 +43,7 @@ func (t *lgTree) numericalDecision(node *lgNode, fval float64) bool {
 		return node.Flags&defaultLeft > 0
 	}
 	// Note: LightGBM uses `<=`, but XGBoost uses `<`
-	return fval <= node.Threshold
+	return fval < node.Threshold
 }
 
 func (t *lgTree) categoricalDecision(node *lgNode, fval float64) bool {

--- a/wrapper.go
+++ b/wrapper.go
@@ -12,12 +12,14 @@ type ForestWrapper struct {
 	FeatureNames   []string
 	TestPrediction float64
 	BestNTreeLimit int
+	TrainingDate   int
 }
 
 type WrapperConfig struct {
 	FeatureNames   []string
 	TestPrediction float64
 	BestNTreeLimit int
+	TrainingDate   int
 }
 
 func NewForestWrapper(modelPath, configPath string) (*ForestWrapper, error) {
@@ -49,6 +51,7 @@ func NewForestWrapper(modelPath, configPath string) (*ForestWrapper, error) {
 		FeatureNames:   config.FeatureNames,
 		TestPrediction: config.TestPrediction,
 		BestNTreeLimit: config.BestNTreeLimit,
+		TrainingDate:   config.TrainingDate,
 	}, nil
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,0 +1,62 @@
+package leaves
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math"
+)
+
+type ForestWrapper struct {
+	Ensemble
+	FeatureNames   []string
+	TestPrediction float64
+}
+
+type WrapperConfig struct {
+	FeatureNames   []string
+	TestPrediction float64
+}
+
+func NewForestWrapper(modelPath, configPath string) (*ForestWrapper, error) {
+	model, err := XGEnsembleFromFile(modelPath, true)
+	if err != nil {
+		return nil, err
+	}
+	var config WrapperConfig
+	// load config from file as json
+	bytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(bytes, &config); err != nil {
+		return nil, err
+	}
+	// doing test prediction
+	fvals := make([]float64, len(config.FeatureNames))
+	for i := 0; i < len(config.FeatureNames); i += 1 {
+		fvals[i] = float64(i)
+	}
+	pred := model.PredictSingle(fvals, 0)
+	// compare with test prediction using epsilon
+	if math.Abs(pred-config.TestPrediction) > 1e-4 {
+		return nil, fmt.Errorf("test prediction failed: %f != %f", pred, config.TestPrediction)
+	}
+	return &ForestWrapper{
+		Ensemble:       *model,
+		FeatureNames:   config.FeatureNames,
+		TestPrediction: config.TestPrediction,
+	}, nil
+}
+
+func (fw *ForestWrapper) PredictSingle(features map[string]float64) (prediction float64, missingCount int) {
+	fvals := make([]float64, len(fw.FeatureNames))
+	for i, featureName := range fw.FeatureNames {
+		fval, ok := features[featureName]
+		if !ok {
+			missingCount += 1
+		}
+		fvals[i] = fval
+	}
+	return fw.Ensemble.PredictSingle(fvals, 0), missingCount
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -11,11 +11,13 @@ type ForestWrapper struct {
 	Ensemble
 	FeatureNames   []string
 	TestPrediction float64
+	BestNTreeLimit int
 }
 
 type WrapperConfig struct {
 	FeatureNames   []string
 	TestPrediction float64
+	BestNTreeLimit int
 }
 
 func NewForestWrapper(modelPath, configPath string) (*ForestWrapper, error) {
@@ -37,7 +39,7 @@ func NewForestWrapper(modelPath, configPath string) (*ForestWrapper, error) {
 	for i := 0; i < len(config.FeatureNames); i += 1 {
 		fvals[i] = float64(i)
 	}
-	pred := model.PredictSingle(fvals, 0)
+	pred := model.PredictSingle(fvals, config.BestNTreeLimit)
 	// compare with test prediction using epsilon
 	if math.Abs(pred-config.TestPrediction) > 1e-4 {
 		return nil, fmt.Errorf("test prediction failed: %f != %f", pred, config.TestPrediction)
@@ -46,6 +48,7 @@ func NewForestWrapper(modelPath, configPath string) (*ForestWrapper, error) {
 		Ensemble:       *model,
 		FeatureNames:   config.FeatureNames,
 		TestPrediction: config.TestPrediction,
+		BestNTreeLimit: config.BestNTreeLimit,
 	}, nil
 }
 
@@ -58,5 +61,5 @@ func (fw *ForestWrapper) PredictSingle(features map[string]float64) (prediction 
 		}
 		fvals[i] = fval
 	}
-	return fw.Ensemble.PredictSingle(fvals, 0), missingCount
+	return fw.Ensemble.PredictSingle(fvals, fw.BestNTreeLimit), missingCount
 }

--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -3,12 +3,10 @@ package leaves
 import (
 	"bufio"
 	"fmt"
-	"math"
-	"os"
-
 	"github.com/dmitryikh/leaves/internal/xgbin"
 	"github.com/dmitryikh/leaves/internal/xgjson"
 	"github.com/dmitryikh/leaves/transformation"
+	"math"
 )
 
 func xgSplitIndex(origNode *xgbin.Node) uint32 {
@@ -252,15 +250,8 @@ func XGEnsembleFromFile(filename string, loadTransformation bool) (*Ensemble, er
 	if ensemble, err := xgEnsembleFromJsonFile(filename, loadTransformation); err == nil {
 		return ensemble, nil
 	} else {
-		panic(err)
-	}
-	reader, err := os.Open(filename)
-	if err != nil {
 		return nil, err
 	}
-	defer reader.Close()
-	bufReader := bufio.NewReader(reader)
-	return XGEnsembleFromReader(bufReader, loadTransformation)
 }
 
 func xgEnsembleFromJsonFile(filename string, loadTransformation bool) (*Ensemble, error) {


### PR DESCRIPTION
### Description 

- Return error in case of failure is encountered when XGBoost model is read from binary file or json file instead of panic
- Remove unreachable code

To make LFR more resilient in context of model(s) not getting downloaded due to any issues - instead of having an alternate older model to be used I believe what we can do is to remove panic in the [model loading code in LFR](https://github.com/ShareChat/moj-feed-relevance/blob/335d7e0374f165744c17c2e34ed06de95158a387/services/livestream-feed-relevance-service/repository/predictionRepo/predictionRepo.go#L119) & in the [cloned leaves library](https://github.com/mgaiduk/leaves/blob/master/xgensemble_io.go#L255). 

This would not cause any downtimes or problems in new pod(s) scaling up as the errors in ranking would be caught at ranking layer & caused Opsgenie alert for the individual model  as the [ranker failure alerts would cross threshold](https://moj-monitoring.sharechat.com/d/Qast8DF4z/livestream-feed-service-relevance-dashboard?viewPanel=27&orgId=1&from=now-24h&to=now). In case of failures for any such specific model(s) the fallback feed will be computed & send (calculated via probabilistic slot based mechanism of CGs)

Slack thread : https://sharechat.slack.com/archives/C042L190A21/p1709886439221059